### PR TITLE
add ignore_unknown_fields as an argument to JSONProtoPayloadConverter

### DIFF
--- a/temporalio/converter.py
+++ b/temporalio/converter.py
@@ -388,6 +388,16 @@ _sym_db = google.protobuf.symbol_database.Default()
 class JSONProtoPayloadConverter(EncodingPayloadConverter):
     """Converter for 'json/protobuf' payloads supporting protobuf Message values."""
 
+    def __init__(self, ignore_unknown_fields: Optional[bool] = False):
+        """Initialize a JSON proto converter.
+
+        Args:
+            ignore_unknown_fields: Determines whether converter should error if
+                unknown fields are detected
+        """
+        super().__init__()
+        self._ignore_unknown_fields = ignore_unknown_fields
+
     @property
     def encoding(self) -> str:
         """See base class."""
@@ -424,7 +434,11 @@ class JSONProtoPayloadConverter(EncodingPayloadConverter):
         message_type = payload.metadata.get("messageType", b"<unknown>").decode()
         try:
             value = _sym_db.GetSymbol(message_type)()
-            return google.protobuf.json_format.Parse(payload.data, value)
+            return google.protobuf.json_format.Parse(
+                payload.data,
+                value,
+                ignore_unknown_fields=self._ignore_unknown_fields,
+            )
         except KeyError as err:
             raise RuntimeError(f"Unknown Protobuf type {message_type}") from err
         except google.protobuf.json_format.ParseError as err:


### PR DESCRIPTION
<!--- For ALL Contributors 👇 -->

## What was changed
This commit enables the `JSONProtoPayloadConverter` to accept `ignore_unknown_fields` as an optional argument so that we can utilize this functionality when converting proto to json.

## Why?
When deploying multiple services out-of-sync with Temporal, proto fields may change in a way that would not necessarily cause the workflow to fail, however without setting the `ignore_unknown_fields` option above, otherwise backwards-compatible proto changes result in conversion errors. As mentioned in the linked issue below, "People may want to ignore unknown fields and right now they have to remake the class themselves"

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-python/issues/315

2. How was this tested:

- Spinning up a worker / workflow that accept an initial version of proto args
- Changing the proto definition in the client triggering the workflow to include an additional field
- Triggering the workflow with the newer version of proto args, while worker/workflow use older version
- Verifying the workflow converts the args and completes successfully

3. Any docs updates needed?
- N/A
